### PR TITLE
make ->attr() work for action

### DIFF
--- a/lib/HTML/Form.pm
+++ b/lib/HTML/Form.pm
@@ -187,7 +187,7 @@ sub parse
     while (my $t = $p->get_tag) {
 	my($tag,$attr) = @$t;
 	if ($tag eq "form") {
-	    my $action = delete $attr->{'action'};
+	    my $action = $attr->{'action'};
 	    $action = "" unless defined $action;
 	    $action = URI->new_abs($action, $base_uri);
 	    $f = $class->new($attr->{'method'},

--- a/t/form.t
+++ b/t/form.t
@@ -3,7 +3,7 @@
 use strict;
 use Test qw(plan ok);
 
-plan tests => 127;
+plan tests => 128;
 
 use HTML::Form;
 
@@ -25,6 +25,7 @@ ok(@f, 2);
 my $f = shift @f;
 ok($f->value("name"), "");
 ok($f->dump, "GET http://localhost/abc [foo]\n  name=                          (text)\n");
+ok( $f->attr('action'), 'abc' );
 
 my $req = $f->click;
 ok($req->method, "GET");


### PR DESCRIPTION
The `->attr()` method did not work for the `action` attribute, because that one got `delete`d in `->parse()`.
I would like it to work for my [new `->form_with()` method in WWW::Mechanize](https://github.com/fany/WWW-Mechanize/commit/bff39f3143eb12e601c57efeeb2fa8d74a368ac5).
