### PR TITLE
Fix the legacy API of "file" inputs

### DIFF
--- a/lib/HTML/Form.pm
+++ b/lib/HTML/Form.pm
@@ -1518,7 +1518,7 @@ sub form_name_value {
 	my $fn = shift @$file;
 	push(@headers, @$file);
 	$file = $f;
-	$filename = $fn unless defined $filename;
+	$filename = $fn;
     }
 
     return ($name => [$file, $filename, @headers]);

--- a/t/file_upload.t
+++ b/t/file_upload.t
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Test::More;
+use HTML::Form;
+
+my ($form, $input);
+
+sub new_form_and_input {
+    $form = HTML::Form->new('POST', '/', 'multipart/form-data');
+    $form->push_input('file', { name => 'document' });
+    ($input) = $form->inputs;
+    return $form, $input;
+}
+
+my $file             = 't/file_upload.txt';
+my $filename         = 'the_uploaded_file.txt';
+
+# Using [$file, $filename] as argument
+
+# $input->value and array refs
+($form, $input) = new_form_and_input;
+$input->value([ $file, $filename ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      'Upload: using $input->value([$file, $filename])' );
+
+# $input->file and array refs
+($form, $input) = new_form_and_input;
+$input->file([ $file, $filename ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      'Upload: using $input->file([$file, $filename])' );
+
+# $form->value and array refs
+($form, $input) = new_form_and_input;
+$form->value('document', [ $file, $filename ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/Upload: using $form->value('document', [$file, $filename])/ );
+
+# Using [$file, $filename, Content => 'inline content'] as argument
+
+# $input->value and array refs
+($form, $input) = new_form_and_input;
+$input->value([ $file, $filename, Content => 'inline content' ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/Upload: using $input->value([$file, $filename, Content => '?'])/ );
+
+# $input->file and array refs
+($form, $input) = new_form_and_input;
+$input->file([ $file, $filename, Content => 'inline content' ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/Upload: using $input->file([$file, $filename, Content => '?'])/ );
+
+# $form->value and array refs
+($form, $input) = new_form_and_input;
+$form->value('document', [ $file, $filename, Content => 'inline content' ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+q/Upload: using $form->value('document', [$file, $filename, Content => '?'])/ );
+
+# Using methods (file, filename, content) directly
+
+# 'file' informed directly
+($form, $input) = new_form_and_input;
+$input->file($file);
+like( $form->make_request->as_string, qr! filename="$file" !x,
+      "Upload: 'file' informed directly and used as 'filename'" );
+
+# 'file' and 'filename' informed directly
+($form, $input) = new_form_and_input;
+$input->file($file);
+$input->filename($filename);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      "Upload: 'file' and 'filename' informed directly" );
+
+# 'file', 'filename' and 'content' informed directly
+($form, $input) = new_form_and_input;
+$input->file($file);
+$input->filename($filename);
+$input->content('inline content');
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      "Upload: 'file', 'filename' and 'content' informed directly" );
+
+done_testing;

--- a/t/file_upload.txt
+++ b/t/file_upload.txt
@@ -1,0 +1,2 @@
+First line.
+Second line.


### PR DESCRIPTION
In the legacy way to handle inputs of type "file", arrayrefs should be
used as their values, according to HTML::Form's line 1515. Examples:

    $input->file(['/tmp/file.txt', filename.txt'])
    $input->value(['/tmp/file.txt', filename.txt'])
    $form->value('document', ['/tmp/file.txt', 'the_filename.txt']).

But the code processing the arrayref has a problem. In the first
example, the HTTP body (generated with $form->make_request->as_string)
should contain `filename="filename.txt"`, but I'm getting
addresses. Example: `filename="ARRAY(0x2ea188)"`.

That's because the arrayref's index 1 (in this case `filename.txt`)
will only be used as the `filename=""` in the HTTP body if a condition
is met in HTML::Form's line 1521.

    $filename = $fn unless defined $filename;

where `$fn` is equal to index 1. The problem is that, when this line is
run, `$filename` cannot be undefined (read &form_name_value at line 1492
and &filename at line 1450). So index 1 won't be used.

The attached patch proposes a fix.
